### PR TITLE
Fix integer overflow issue in pixel_to_cel function by using np.int64_t

### DIFF
--- a/pyxsim/lib/sky_functions.pyx
+++ b/pyxsim/lib/sky_functions.pyx
@@ -154,8 +154,8 @@ def pixel_to_cel(np.ndarray[np.float64_t, ndim=1] xsky,
                  np.ndarray[np.float64_t, ndim=1] ysky,
                  np.ndarray[np.float64_t, ndim=1] sky_center):
 
-    cdef int i
-    cdef int n = xsky.size
+    cdef np.int64_t i
+    cdef np.int64_t n = xsky.size
     cdef np.float64_t B, D, cx, cy, sin_cy, cos_cy
     cdef np.float64_t PI = np.pi
 


### PR DESCRIPTION
**Issue:**
While using the `make_photons` function with a very large exposure time, I encountered a Python error, `OverflowError: value too large to convert to integer`. This error occurred during the call to the `pixel_to_cel` function in the `sky_functions.pyx` file.

**Cause:**
The error was traced to the use of a default 32-bit integer (`int`) in the `pixel_to_cel` function, which could not handle the large number of photons generated.

**Solution:**
I updated the function definition to use 64-bit integers (`np.int64_t`) for the loop index and size variables:
- Changed `cdef int i` to `cdef np.int64_t i`
- Changed `cdef int n = xsky.size` to `cdef np.int64_t n = xsky.size`

These changes ensure that the function can handle large values without causing an overflow.  Updating this part and rebuilding the Cython file could help avoid potential errors, even if really rare.

**Additional Information:**
While this issue might not occur frequently under typical usage, updating these integer definitions helps prevent potential errors in edge cases involving an overwhelming number of photons emitted from data sets.
